### PR TITLE
Pass NIL value for fdw_scan_tlist to fix compilation for 9.5 alpha 2

### DIFF
--- a/json_fdw.c
+++ b/json_fdw.c
@@ -310,7 +310,8 @@ JsonGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreignTableId,
 	/* create the foreign scan node */
 	foreignScan = make_foreignscan(targetList, scanClauses, baserel->relid, 
 								   NIL, /* no expressions to evaluate */
-								   foreignPrivateList);
+								   foreignPrivateList,
+								   NIL /* no fdw_scan_tlist */);
 
 	return foreignScan;
 }


### PR DESCRIPTION
This PR addresses Issue #5

This passes in a `NIL` value for `fdw_scan_tlist` which fixes compilation targeting PostgreSQL 9.5.
